### PR TITLE
fix: Update Rust toolchain channel from nightly to stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"


### PR DESCRIPTION
This pull request includes a small but significant change to the `rust-toolchain.toml` file. The change updates the Rust toolchain channel from `nightly` to `stable`, ensuring greater stability and compatibility for the project.

## Summary

Summary about this PR

- Closes #issue